### PR TITLE
Fix S3 CORS default origin handling

### DIFF
--- a/file-upload/src/S3.test.ts
+++ b/file-upload/src/S3.test.ts
@@ -1,0 +1,26 @@
+import { S3Storage } from './S3';
+
+describe('S3Storage CORS origins', () => {
+  const original = process.env.S3_CORS_ORIGINS;
+  const dummyS3 = {} as any;
+
+  afterEach(() => {
+    if (original === undefined) {
+      delete process.env.S3_CORS_ORIGINS;
+    } else {
+      process.env.S3_CORS_ORIGINS = original;
+    }
+  });
+
+  it('defaults to wildcard when env var is not set', () => {
+    delete process.env.S3_CORS_ORIGINS;
+    const storage = new S3Storage({ s3Sdk: dummyS3, bucketName: 'b' });
+    expect((storage as any).corsOrigins).toEqual(['*']);
+  });
+
+  it('filters out empty strings from env var', () => {
+    process.env.S3_CORS_ORIGINS = '*,,';
+    const storage = new S3Storage({ s3Sdk: dummyS3, bucketName: 'b' });
+    expect((storage as any).corsOrigins).toEqual(['*']);
+  });
+});

--- a/file-upload/src/S3.ts
+++ b/file-upload/src/S3.ts
@@ -2,7 +2,13 @@ import Aws from 'aws-sdk';
 import { MetadataFile } from './FileManager';
 import { Storage } from './Storage';
 
-const CORS_ORIGINS = (process.env.S3_CORS_ORIGINS || '').split(',');
+// When S3_CORS_ORIGINS isn't specified we default to allowing any origin.
+// The previous implementation produced `[""]` which caused AWS SDK to
+// reject the CORS configuration. Filter out empty strings so the configuration
+// is always valid.
+const CORS_ORIGINS = (process.env.S3_CORS_ORIGINS || '*')
+  .split(',')
+  .filter(Boolean);
 
 export interface S3Options {
   s3Sdk?: Aws.S3;


### PR DESCRIPTION
## Summary
- fix default S3 CORS origins handling in `file-upload` library
- add regression tests for `S3Storage` constructor

## Testing
- `yarn test` *(fails: package not in lockfile)*
- `yarn install` *(fails due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_684b3e47b3e4832a8014fb17bae4184d