### PR TITLE
Fix Hermes environment path

### DIFF
--- a/PROGRESS_REPORT.md
+++ b/PROGRESS_REPORT.md
@@ -150,6 +150,8 @@ cd hermes
 # Vérifier que le chemin DB est : file:../noodle-shared/prisma/dev.db
 # Pas : file:../noodle-shared/prisma/../noodle-shared/prisma/dev.db
 ```
+✅ Chemin corrigé : `hermes/.env` mis à jour avec
+`DATABASE_URL=file:../noodle-shared/prisma/dev.db`
 
 ### **ÉTAPE 2 : Réparer NOODLE-API**
 ```bash


### PR DESCRIPTION
## Summary
- document correct Hermes DATABASE_URL

## Testing
- `yarn test:component` *(fails: This package doesn't seem to be present in your lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_6856fc8b4364832abe881bc5b707f085